### PR TITLE
Add week navigation for progress page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:habits_go_front/screens/user_settings_screen.dart';
 import 'package:habits_go_front/screens/daily_plan_screen.dart';
 import 'package:habits_go_front/screens/daily_plan_loading.dart';
 import 'package:habits_go_front/screens/favorite_foods_screen.dart';
+import 'package:habits_go_front/screens/habits_questionnaire_screen.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -60,6 +61,7 @@ class MainApp extends StatelessWidget {
           );
         },
         "user_settings": (context) => const UserSettingsScreen(),
+        "habit_questionnaire": (context) => const HabitsQuestionnaireScreen(),
         "daily_plan": (context) => const DailyPlanScreen(),
         "favorite_foods": (context) => const FavoriteFoodsScreen(),
         "alerts": (context) => const AlertsScreen(),

--- a/lib/screens/habits_questionnaire_screen.dart
+++ b/lib/screens/habits_questionnaire_screen.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/user_provider.dart';
+import '../services/habit_service.dart';
+
+class HabitsQuestionnaireScreen extends StatefulWidget {
+  const HabitsQuestionnaireScreen({super.key});
+
+  @override
+  State<HabitsQuestionnaireScreen> createState() => _HabitsQuestionnaireScreenState();
+}
+
+class _HabitsQuestionnaireScreenState extends State<HabitsQuestionnaireScreen> {
+  final _exerciseController = TextEditingController();
+  final _waterController = TextEditingController();
+  bool _smokes = false;
+  bool _sleepEnough = true;
+  bool _loading = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _exerciseController.dispose();
+    _waterController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final exercise = int.tryParse(_exerciseController.text.trim());
+    final water = int.tryParse(_waterController.text.trim());
+
+    if (exercise == null || water == null) {
+      setState(() => _error = 'Por favor completa todos los campos num\u00e9ricos');
+      return;
+    }
+
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    final userId = Provider.of<UserProvider>(context, listen: false).userId!;
+    final service = HabitService();
+    final data = {
+      'exercise_days': exercise,
+      'smokes': _smokes,
+      'water_glasses': water,
+      'sleep_7h': _sleepEnough,
+    };
+
+    try {
+      await service.submitHabits(userId, data);
+      if (mounted) {
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      setState(() => _error = 'Error al guardar los h\u00e1bitos');
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cuestionario de H\u00e1bitos'),
+        backgroundColor: const Color(0xFF226980),
+        foregroundColor: Colors.white,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _exerciseController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(
+                labelText: 'D\u00edas de ejercicio por semana',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SwitchListTile(
+              title: const Text('\u00bfFumas?'),
+              value: _smokes,
+              onChanged: (v) => setState(() => _smokes = v),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _waterController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(
+                labelText: 'Vasos de agua al d\u00eda',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SwitchListTile(
+              title: const Text('\u00bfDuermes al menos 7 horas?'),
+              value: _sleepEnough,
+              onChanged: (v) => setState(() => _sleepEnough = v),
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 8),
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+            ],
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _loading ? null : _submit,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF226980),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child: _loading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                      )
+                    : const Text('Guardar h\u00e1bitos'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -17,6 +17,16 @@ class _ProgressScreenState extends State<ProgressScreen> {
   String mostProductiveDay = '-';
   String mealsSummary = '-';
   List<int> weeklyEvolutionData = [];
+  int weekOffset = 0;
+
+  String get weekRangeLabel {
+    DateTime now = DateTime.now();
+    DateTime monday = now.subtract(Duration(days: now.weekday - 1 + weekOffset * 7));
+    DateTime sunday = monday.add(const Duration(days: 6));
+    String start = '${monday.day}/${monday.month}';
+    String end = '${sunday.day}/${sunday.month}';
+    return 'Semana del $start al $end';
+  }
 
   @override
   void initState() {
@@ -32,10 +42,10 @@ class _ProgressScreenState extends State<ProgressScreen> {
       final userService = UserService();
 
       final results = await Future.wait([
-        userService.getWeeklyCompletion(userId),
-        userService.getMostProductiveDay(userId),
-        userService.getMealsSummary(userId),
-        userService.getWeeklyEvolution(userId)
+        userService.getWeeklyCompletion(userId, weekOffset: weekOffset),
+        userService.getMostProductiveDay(userId, weekOffset: weekOffset),
+        userService.getMealsSummary(userId, weekOffset: weekOffset),
+        userService.getWeeklyEvolution(userId, weekOffset: weekOffset)
       ]);
 
       setState(() {
@@ -88,6 +98,34 @@ class _ProgressScreenState extends State<ProgressScreen> {
               style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white, fontSize: 18),
             ),
             SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.arrow_back),
+                  onPressed: () {
+                    setState(() {
+                      weekOffset += 1;
+                    });
+                    fetchProgressData();
+                  },
+                ),
+                Text(
+                  weekRangeLabel,
+                  style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.arrow_forward),
+                  onPressed: weekOffset > 0 ? () {
+                          setState(() {
+                            weekOffset -= 1;
+                          });
+                          fetchProgressData();
+                        } : null,
+                ),
+              ],
+            ),
+            SizedBox(height: 8),
             Expanded(
               child: Container(
                 padding: EdgeInsets.only(top: 24, left: 16, right: 16, bottom: 24),

--- a/lib/screens/user_settings_screen.dart
+++ b/lib/screens/user_settings_screen.dart
@@ -199,6 +199,28 @@ class _UserSettingsScreenState extends State<UserSettingsScreen> {
                 ),
               ),
             ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: () => Navigator.pushNamed(context, 'habit_questionnaire'),
+                  icon: const Icon(Icons.assignment),
+                  label: const Text(
+                    'Cambiar H\u00e1bitos',
+                    style: TextStyle(fontSize: 18),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    backgroundColor: Color(0xFF226980),
+                    foregroundColor: Colors.white,
+                  ),
+                ),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/services/habit_service.dart
+++ b/lib/services/habit_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../config/env.dart';
+
+class HabitService {
+  static const String _baseUrl = '${Env.baseUrl}/user';
+
+  Future<void> submitHabits(int userId, Map<String, dynamic> habits) async {
+    final url = Uri.parse('$_baseUrl/$userId/habits');
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(habits),
+    );
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw Exception('Error al actualizar habitos: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -21,8 +21,8 @@ class UserService {
     }
   }
 
-  Future<int> getWeeklyCompletion(int userId) async {
-    final url = Uri.parse('$_baseUrl/$userId/weekly/completion');
+  Future<int> getWeeklyCompletion(int userId, {int weekOffset = 0}) async {
+    final url = Uri.parse('$_baseUrl/$userId/weekly/completion?weekOffset=$weekOffset');
 
     try {
       final response = await http.get(url);
@@ -36,8 +36,8 @@ class UserService {
     }
   }
 
-  Future<String> getMostProductiveDay(int userId) async {
-    final url = Uri.parse('$_baseUrl/$userId/weekly/top/days');
+  Future<String> getMostProductiveDay(int userId, {int weekOffset = 0}) async {
+    final url = Uri.parse('$_baseUrl/$userId/weekly/top/days?weekOffset=$weekOffset');
 
     try {
       final response = await http.get(url);
@@ -51,8 +51,8 @@ class UserService {
     }
   }
 
-  Future<String> getMealsSummary(int userId) async {
-    final url = Uri.parse('$_baseUrl/$userId/meal/completion/summary');
+  Future<String> getMealsSummary(int userId, {int weekOffset = 0}) async {
+    final url = Uri.parse('$_baseUrl/$userId/meal/completion/summary?weekOffset=$weekOffset');
 
     try {
       final response = await http.get(url);
@@ -66,8 +66,8 @@ class UserService {
     }
   }
 
-  Future<List<int>> getWeeklyEvolution(int userId) async {
-    final url = Uri.parse('$_baseUrl/$userId/weekly/evolution');
+  Future<List<int>> getWeeklyEvolution(int userId, {int weekOffset = 0}) async {
+    final url = Uri.parse('$_baseUrl/$userId/weekly/evolution?weekOffset=$weekOffset');
 
     try {
       final response = await http.get(url);


### PR DESCRIPTION
## Summary
- enable specifying a week offset in `UserService` requests
- show a weekly history navigator in `ProgressScreen`
- add a habit questionnaire screen to update user habits
- connect profile button to the new questionnaire via `habit_questionnaire` route

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f02a06bf48325909eada6ae2b3b65